### PR TITLE
Refactor forms to use btn utility

### DIFF
--- a/app/auth/login.jsx
+++ b/app/auth/login.jsx
@@ -52,12 +52,12 @@ export default function LoginPage() {
           {err && (
             <motion.div animate={{ scale: [0.8, 1], color: "#f43f5e" }} className="text-sm text-red-500">{err}</motion.div>
           )}
-          <motion.button 
-            whileHover={{ scale: 1.02 }} 
-            whileTap={{ scale: 0.98 }} 
-            type="submit" 
-            disabled={loading} 
-            className="w-full p-3 rounded-lg bg-blue-500 text-white font-semibold mt-4"
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            type="submit"
+            disabled={loading}
+            className="btn btn-blue w-full font-semibold mt-4"
           >
             {loading ? "Loading..." : "Login"}
           </motion.button>

--- a/app/auth/register.jsx
+++ b/app/auth/register.jsx
@@ -30,7 +30,7 @@ export default function RegisterPage() {
           <input type="email" className="w-full p-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition" placeholder="Email" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} required />
           <input type="password" className="w-full p-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition" placeholder="Password" value={form.password} onChange={e => setForm(f => ({ ...f, password: e.target.value }))} required />
           {err && <motion.div animate={{ scale: [0.8, 1], color: "#f43f5e" }} className="text-sm text-red-500">{err}</motion.div>}
-          <motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} type="submit" disabled={loading} className="w-full p-3 rounded-lg bg-blue-500 text-white font-semibold mt-4">
+          <motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} type="submit" disabled={loading} className="btn btn-blue w-full font-semibold mt-4">
             {loading ? "Loading..." : "Daftar"}
           </motion.button>
         </form>

--- a/components/AdminProductForm.jsx
+++ b/components/AdminProductForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { motion } from "framer-motion";
 import ImageUpload from "./ImageUpload";
 export default function AdminProductForm({ onSave, product }) {
   const [form, setForm] = useState(product || { name: "", description: "", price: "", imageUrl: "" });
@@ -12,7 +13,14 @@ export default function AdminProductForm({ onSave, product }) {
       <textarea value={form.description} onChange={e => setForm(f => ({ ...f, description: e.target.value }))} className="input" placeholder="Deskripsi" />
       <input value={form.price} onChange={e => setForm(f => ({ ...f, price: e.target.value }))} className="input" type="number" placeholder="Harga" required />
       <ImageUpload value={form.imageUrl} onChange={url => setForm(f => ({ ...f, imageUrl: url }))} />
-      <button type="submit" className="btn bg-blue-500 text-white px-4 py-2 rounded-xl">Simpan</button>
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        type="submit"
+        className="btn btn-blue"
+      >
+        Simpan
+      </motion.button>
     </form>
   );
 }

--- a/components/AdminSettingForm.jsx
+++ b/components/AdminSettingForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { motion } from "framer-motion";
 export default function AdminSettingForm() {
   const [form, setForm] = useState({ orkutKey: "", okeConnectKey: "", googleClientId: "" });
   const submit = e => { e.preventDefault(); /* save API /api/admin/settings */ };
@@ -7,7 +8,13 @@ export default function AdminSettingForm() {
       <input value={form.orkutKey} onChange={e => setForm(f => ({ ...f, orkutKey: e.target.value }))} className="input" placeholder="Orkut API Key" />
       <input value={form.okeConnectKey} onChange={e => setForm(f => ({ ...f, okeConnectKey: e.target.value }))} className="input" placeholder="OkeConnect API Key" />
       <input value={form.googleClientId} onChange={e => setForm(f => ({ ...f, googleClientId: e.target.value }))} className="input" placeholder="Google Client ID" />
-      <button className="btn bg-blue-500 text-white px-4 py-2 rounded-xl">Simpan Setting</button>
+      <motion.button
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        className="btn btn-blue"
+      >
+        Simpan Setting
+      </motion.button>
     </form>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,7 +14,10 @@
 
 .text-neon { color: #8ecafe; text-shadow: 0 0 8px #7b8fff88; }
 .input { @apply w-full p-2 rounded border focus:outline-blue-400; }
-.btn { @apply transition duration-150; }
+.btn { @apply px-4 py-2 rounded-lg transition duration-150; }
+.btn-blue { @apply bg-blue-500 text-white; }
+.btn-red { @apply bg-red-500 text-white; }
+.btn-green { @apply bg-green-500 text-white; }
 
 .badge-success { @apply bg-green-500 text-white px-2 py-0.5 rounded; }
 .badge-warning { @apply bg-yellow-500 text-white px-2 py-0.5 rounded; }


### PR DESCRIPTION
## Summary
- simplify global `.btn` class and add color variants
- use the btn utility in login and register pages
- convert admin forms to use motion buttons with color variants

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685683f03268833188b9737ec633b149