### PR TITLE
Remove unused useTheme hook

### DIFF
--- a/hooks/useTheme.js
+++ b/hooks/useTheme.js
@@ -1,5 +1,0 @@
-import { useContext } from "react";
-import { ThemeContext } from "@/components/ThemeProvider";
-export default function useTheme() {
-  return useContext(ThemeContext);
-}


### PR DESCRIPTION
## Summary
- remove the unused `hooks/useTheme.js`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856a867c29c8331b2b424e9bec7aac8