### PR TITLE
Add GoogleOAuth to Providers component

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,13 +1,11 @@
-import { GoogleOAuthProvider } from "@react-oauth/google";
 import "@/styles/globals.css";
+import Providers from "@/components/Providers";
 
 export default function RootLayout({ children }) {
   return (
     <html lang="id">
       <body>
-        <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}>
-          {children}
-        </GoogleOAuthProvider>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/components/Providers.jsx
+++ b/components/Providers.jsx
@@ -1,11 +1,14 @@
 "use client";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 import { ParallaxProvider } from "react-scroll-parallax";
 import { ThemeProvider } from "./ThemeProvider";
 
 export default function Providers({ children }) {
   return (
-    <ParallaxProvider>
-      <ThemeProvider>{children}</ThemeProvider>
-    </ParallaxProvider>
+    <GoogleOAuthProvider clientId={process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}>
+      <ParallaxProvider>
+        <ThemeProvider>{children}</ThemeProvider>
+      </ParallaxProvider>
+    </GoogleOAuthProvider>
   );
 }


### PR DESCRIPTION
## Summary
- expand `Providers` to include `GoogleOAuthProvider`
- consume `Providers` in the layout and remove direct provider usage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856a872df608331906af8dbf1c92238