### PR TITLE
Add client directive to AdminSettingForm

### DIFF
--- a/components/AdminSettingForm.jsx
+++ b/components/AdminSettingForm.jsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from "react";
 import { motion } from "framer-motion";
 export default function AdminSettingForm() {


### PR DESCRIPTION
## Summary
- enable client-side hooks in `AdminSettingForm`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856a992c18c8331be363dfa3b754655