### PR TITLE
Fix Recharts components for client rendering

### DIFF
--- a/components/AnimatedChart.jsx
+++ b/components/AnimatedChart.jsx
@@ -1,3 +1,4 @@
+"use client";
 import { ResponsiveContainer, LineChart, Line, Tooltip, XAxis, YAxis } from "recharts";
 export default function AnimatedChart({ data }) {
   return (

--- a/components/FunnelChart.jsx
+++ b/components/FunnelChart.jsx
@@ -1,3 +1,4 @@
+"use client";
 import { Funnel, FunnelChart, Tooltip, LabelList } from "recharts";
 export default function FunnelChartComp() {
   const data = [


### PR DESCRIPTION
## Summary
- ensure Recharts components run on the client by adding the `"use client"` directive to `AnimatedChart.jsx` and `FunnelChart.jsx`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6856a993fcf88331b3a76019ebcd1a79