### PR TITLE
Fix useTheme hook import

### DIFF
--- a/hooks/useTheme.js
+++ b/hooks/useTheme.js
@@ -1,5 +1,3 @@
-import { useContext } from "react";
-import { ThemeContext } from "@/components/ThemeProvider";
-export default function useTheme() {
-  return useContext(ThemeContext);
-}
+// Re-export the `useTheme` hook from the ThemeProvider so consumers of
+// this file receive the correct context instance.
+export { useTheme as default } from "@/components/ThemeProvider";


### PR DESCRIPTION
## Summary
- re-export `useTheme` from the ThemeProvider for proper context access

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856a994a6208331ad820e05ad59a3ef