### PR TITLE
Configure Crisp ID via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.js`. The page auto-updates
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables
+
+Certain features require configuration via environment variables. To enable the live chat widget powered by Crisp, set the following variable in your environment:
+
+```bash
+NEXT_PUBLIC_CRISP_ID=<your-crisp-website-id>
+```
+
+If this variable is not provided the chat widget will be disabled.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/components/LiveChatWidget.jsx
+++ b/components/LiveChatWidget.jsx
@@ -2,9 +2,20 @@
 import { useEffect } from "react";
 export default function LiveChatWidget() {
   useEffect(() => {
-    window.$crisp = []; window.CRISP_WEBSITE_ID = "YOUR-CRISP-ID";
-    const d = document, s = d.createElement("script");
-    s.src = "https://client.crisp.chat/l.js"; s.async = 1; d.getElementsByTagName("head")[0].appendChild(s);
+    const crispId = process.env.NEXT_PUBLIC_CRISP_ID;
+    if (!crispId) {
+      console.warn(
+        "Crisp chat disabled: NEXT_PUBLIC_CRISP_ID environment variable not set."
+      );
+      return;
+    }
+    window.$crisp = [];
+    window.CRISP_WEBSITE_ID = crispId;
+    const d = document,
+      s = d.createElement("script");
+    s.src = "https://client.crisp.chat/l.js";
+    s.async = 1;
+    d.getElementsByTagName("head")[0].appendChild(s);
   }, []);
   return null;
 }


### PR DESCRIPTION
## Summary
- fetch Crisp website ID from `NEXT_PUBLIC_CRISP_ID`
- add docs for the new environment variable

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b4b5fdec83318c51cfb2429fb1c4