### PR TITLE
Fix duplicate import in Providers

### DIFF
--- a/components/Providers.jsx
+++ b/components/Providers.jsx
@@ -1,7 +1,6 @@
 "use client";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { ParallaxProvider } from "react-scroll-parallax";
-import { GoogleOAuthProvider } from "@react-oauth/google";
 import { ThemeProvider } from "./ThemeProvider";
 
 export default function Providers({ children }) {


### PR DESCRIPTION
## Summary
- deduplicate the `GoogleOAuthProvider` import in `Providers.jsx`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b4b6b2388331bdcb417544c0321b