### PR TITLE
Implement simple heatmap API

### DIFF
--- a/app/api/analytics/heatmap/route.js
+++ b/app/api/analytics/heatmap/route.js
@@ -1,0 +1,18 @@
+const clicks = [];
+
+export async function POST(request) {
+  try {
+    const { page, x, y } = await request.json();
+    if (typeof x !== 'number' || typeof y !== 'number') {
+      throw new Error('Invalid coordinates');
+    }
+    clicks.push({ page, x, y, ts: Date.now() });
+    return Response.json({ status: true });
+  } catch (err) {
+    return Response.json({ status: false, error: err.message || 'Invalid request' }, { status: 400 });
+  }
+}
+
+export async function GET() {
+  return Response.json({ status: true, data: clicks });
+}

--- a/hooks/useHeatmap.js
+++ b/hooks/useHeatmap.js
@@ -3,7 +3,11 @@ export default function useHeatmap(page) {
   useEffect(() => {
     const handleClick = e => {
       const { x, y } = e;
-      fetch("/api/analytics/heatmap", { method: "POST", body: JSON.stringify({ page, x, y }) });
+      fetch("/api/analytics/heatmap", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ page, x, y })
+      }).catch(err => console.error("Heatmap error", err));
     };
     window.addEventListener("click", handleClick);
     return () => window.removeEventListener("click", handleClick);


### PR DESCRIPTION
## Summary
- add a small API handler for storing click coordinates
- send JSON data in useHeatmap and log any errors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b4b8ad7c8331acdc1f0ead643148