### PR TITLE
Implement basic auth API

### DIFF
--- a/app/api/auth/google/route.js
+++ b/app/api/auth/google/route.js
@@ -1,3 +1,35 @@
-export async function POST() {
-  return Response.json({ status: false, error: 'Google login not implemented' }, { status: 501 });
+import { randomBytes } from 'crypto';
+import { createUser, getUserByEmail } from '@/lib/db';
+import { sign } from '@/lib/jwt';
+
+export async function POST(request) {
+  const { credential } = await request.json();
+  if (!credential) {
+    return Response.json({ status: false, error: 'Credential tidak valid' }, { status: 400 });
+  }
+  try {
+    const payloadPart = credential.split('.')[1];
+    const payload = JSON.parse(Buffer.from(payloadPart, 'base64').toString());
+    const email = payload.email;
+    const name = payload.name || payload.given_name || 'Google User';
+    if (!email) throw new Error('invalid');
+
+    let user = await getUserByEmail(email);
+    if (!user) {
+      user = {
+        id: randomBytes(16).toString('hex'),
+        email,
+        name,
+        passwordHash: null,
+        role: 'USER',
+        createdAt: new Date().toISOString()
+      };
+      await createUser(user);
+    }
+
+    const token = sign({ id: user.id, email: user.email }, { expiresIn: 60 * 60 * 24 * 7 });
+    return Response.json({ status: true, token });
+  } catch {
+    return Response.json({ status: false, error: 'Credential tidak valid' }, { status: 400 });
+  }
 }

--- a/app/api/auth/login/route.js
+++ b/app/api/auth/login/route.js
@@ -1,3 +1,20 @@
-export async function POST() {
-  return Response.json({ status: false, error: 'Login not implemented' }, { status: 501 });
+import { createHash } from 'crypto';
+import { getUserByEmail } from '@/lib/db';
+import { sign } from '@/lib/jwt';
+
+export async function POST(request) {
+  const { email, password } = await request.json();
+  if (!email || !password) {
+    return Response.json({ status: false, error: 'Email dan password wajib' }, { status: 400 });
+  }
+  const user = await getUserByEmail(email);
+  if (!user) {
+    return Response.json({ status: false, error: 'User tidak ditemukan' }, { status: 401 });
+  }
+  const hash = createHash('sha256').update(password).digest('hex');
+  if (user.passwordHash !== hash) {
+    return Response.json({ status: false, error: 'Password salah' }, { status: 401 });
+  }
+  const token = sign({ id: user.id, email: user.email }, { expiresIn: 60 * 60 * 24 * 7 });
+  return Response.json({ status: true, token });
 }

--- a/app/api/auth/me/route.js
+++ b/app/api/auth/me/route.js
@@ -1,3 +1,17 @@
-export async function GET() {
-  return Response.json({ status: true, data: { name: 'Demo User' } });
+import { getUserById } from '@/lib/db';
+import { verify } from '@/lib/jwt';
+
+export async function GET(request) {
+  const auth = request.headers.get('authorization') || '';
+  const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+  const payload = verify(token);
+  if (!payload) {
+    return Response.json({ status: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await getUserById(payload.id);
+  if (!user) {
+    return Response.json({ status: false, error: 'Unauthorized' }, { status: 401 });
+  }
+  const { passwordHash, ...data } = user;
+  return Response.json({ status: true, data });
 }

--- a/app/api/auth/register/route.js
+++ b/app/api/auth/register/route.js
@@ -1,3 +1,41 @@
-export async function POST() {
-  return Response.json({ status: false, error: 'Registration not implemented' }, { status: 501 });
+import { randomBytes, createHash } from 'crypto';
+import { createUser, getUserByEmail } from '@/lib/db';
+import { sign } from '@/lib/jwt';
+
+function validateEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function POST(request) {
+  const { email, password, name } = await request.json();
+  if (!email || !password || !name) {
+    return Response.json({ status: false, error: 'Data tidak lengkap' }, { status: 400 });
+  }
+  if (!validateEmail(email)) {
+    return Response.json({ status: false, error: 'Email tidak valid' }, { status: 400 });
+  }
+  if (password.length < 6) {
+    return Response.json({ status: false, error: 'Password minimal 6 karakter' }, { status: 400 });
+  }
+
+  const existing = await getUserByEmail(email);
+  if (existing) {
+    return Response.json({ status: false, error: 'Email sudah terdaftar' }, { status: 400 });
+  }
+
+  const passwordHash = createHash('sha256').update(password).digest('hex');
+  const user = {
+    id: randomBytes(16).toString('hex'),
+    email,
+    name,
+    passwordHash,
+    role: 'USER',
+    createdAt: new Date().toISOString()
+  };
+
+  await createUser(user);
+
+  const token = sign({ id: user.id, email: user.email }, { expiresIn: 60 * 60 * 24 * 7 });
+
+  return Response.json({ status: true, token });
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,39 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const file = path.join(process.cwd(), 'db.json');
+
+async function read() {
+  try {
+    const data = await fs.readFile(file, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      const init = { users: [] };
+      await fs.writeFile(file, JSON.stringify(init, null, 2));
+      return init;
+    }
+    throw err;
+  }
+}
+
+async function write(data) {
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+}
+
+export async function getUserByEmail(email) {
+  const db = await read();
+  return db.users.find(u => u.email === email);
+}
+
+export async function getUserById(id) {
+  const db = await read();
+  return db.users.find(u => u.id === id);
+}
+
+export async function createUser(user) {
+  const db = await read();
+  db.users.push(user);
+  await write(db);
+  return user;
+}

--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -1,0 +1,36 @@
+import { createHmac } from 'crypto';
+
+const SECRET = process.env.JWT_SECRET || 'secret';
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64url');
+}
+
+export function sign(payload, { expiresIn } = {}) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const ts = Math.floor(Date.now() / 1000);
+  const data = { ...payload };
+  if (expiresIn) data.exp = ts + expiresIn;
+  const headerB64 = base64url(JSON.stringify(header));
+  const payloadB64 = base64url(JSON.stringify(data));
+  const content = `${headerB64}.${payloadB64}`;
+  const signature = createHmac('sha256', SECRET).update(content).digest('base64url');
+  return `${content}.${signature}`;
+}
+
+export function verify(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, signature] = parts;
+  const content = `${headerB64}.${payloadB64}`;
+  const expected = createHmac('sha256', SECRET).update(content).digest('base64url');
+  if (expected !== signature) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString());
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
+    return payload;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight file-based db utilities
- implement JWT token generation and verification
- flesh out register/login/google auth routes
- secure me route with JWT validation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b4b9e6388331b84ef17f7575f3c6