### PR TITLE
Add admin route guard

### DIFF
--- a/app/403/page.jsx
+++ b/app/403/page.jsx
@@ -1,0 +1,8 @@
+export default function Forbidden() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-4xl font-bold mb-4">403</h1>
+      <p className="text-lg">Akses tidak diizinkan</p>
+    </div>
+  );
+}

--- a/app/admin/orders/page.jsx
+++ b/app/admin/orders/page.jsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from "react";
 import AdminSidebar from "@/components/AdminSidebar";
 import AdminOrderTable from "@/components/AdminOrderTable";
 import ConfirmModal from "@/components/ConfirmModal";
+import useAdminGuard from "@/hooks/useAdminGuard";
 
 export default function AdminOrders() {
+  useAdminGuard();
   const [orders, setOrders] = useState([]);
   const [deleting, setDeleting] = useState(null);
 

--- a/app/admin/page.jsx
+++ b/app/admin/page.jsx
@@ -1,7 +1,10 @@
+"use client";
 import AdminSidebar from "@/components/AdminSidebar";
 import AnimatedChart from "@/components/AnimatedChart";
+import useAdminGuard from "@/hooks/useAdminGuard";
 
 export default function AdminDashboard() {
+  useAdminGuard();
   return (
     <div className="flex min-h-screen">
       <AdminSidebar />

--- a/app/admin/products/page.jsx
+++ b/app/admin/products/page.jsx
@@ -4,8 +4,10 @@ import AdminSidebar from "@/components/AdminSidebar";
 import AdminProductForm from "@/components/AdminProductForm";
 import AnimatedTable from "@/components/AnimatedTable";
 import ConfirmModal from "@/components/ConfirmModal";
+import useAdminGuard from "@/hooks/useAdminGuard";
 
 export default function AdminProducts() {
+  useAdminGuard();
   const [products, setProducts] = useState([]);
   const [editing, setEditing] = useState(null), [deleting, setDeleting] = useState(null);
 

--- a/app/admin/settings/page.jsx
+++ b/app/admin/settings/page.jsx
@@ -1,7 +1,10 @@
+"use client";
 import AdminSidebar from "@/components/AdminSidebar";
 import AdminSettingForm from "@/components/AdminSettingForm";
+import useAdminGuard from "@/hooks/useAdminGuard";
 
 export default function AdminSettings() {
+  useAdminGuard();
   return (
     <div className="flex min-h-screen">
       <AdminSidebar />

--- a/app/admin/users/page.jsx
+++ b/app/admin/users/page.jsx
@@ -2,8 +2,10 @@
 import { useEffect, useState } from "react";
 import AdminSidebar from "@/components/AdminSidebar";
 import AdminUserTable from "@/components/AdminUserTable";
+import useAdminGuard from "@/hooks/useAdminGuard";
 
 export default function AdminUsers() {
+  useAdminGuard();
   const [users, setUsers] = useState([]);
 
   useEffect(() => {

--- a/app/api/auth/me/route.js
+++ b/app/api/auth/me/route.js
@@ -1,3 +1,3 @@
 export async function GET() {
-  return Response.json({ status: true, data: { name: 'Demo User' } });
+  return Response.json({ status: true, data: { name: 'Demo User', role: 'admin' } });
 }

--- a/hooks/useAdminGuard.js
+++ b/hooks/useAdminGuard.js
@@ -1,0 +1,16 @@
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import useAuth from "./useAuth";
+
+export default function useAdminGuard() {
+  const user = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user && user.role !== "admin") {
+      router.replace("/403");
+    }
+  }, [user, router]);
+
+  return user;
+}


### PR DESCRIPTION
## Summary
- add useAdminGuard hook for access control
- add /403 page for unauthorized access
- enforce admin role check in admin pages
- return role from `/api/auth/me`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b4b451348331ac52a7b01d873c87