### PR TITLE
Add auth page navigation links

### DIFF
--- a/app/auth/login/page.jsx
+++ b/app/auth/login/page.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import GlassCard from "@/components/GlassCard";
 import { GoogleLogin } from "@react-oauth/google";
 import { motion } from "framer-motion";
+import Link from "next/link";
 
 export default function LoginPage() {
   const [email, setEmail] = useState(""); 
@@ -61,6 +62,12 @@ export default function LoginPage() {
             {loading ? "Loading..." : "Login"}
           </motion.button>
         </form>
+        <Link
+          href="/auth/register"
+          className="block text-center text-sm text-blue-500 dark:text-neon hover:underline"
+        >
+          Belum punya akun? Daftar
+        </Link>
         <div className="mt-6 flex flex-col gap-2">
           <GoogleLogin
             onSuccess={credentialResponse => {

--- a/app/auth/register/page.jsx
+++ b/app/auth/register/page.jsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import GlassCard from "@/components/GlassCard";
 import { motion } from "framer-motion";
+import Link from "next/link";
 
 export default function RegisterPage() {
   const [form, setForm] = useState({ email: "", password: "", name: "" });
@@ -75,6 +76,12 @@ export default function RegisterPage() {
             {loading ? "Loading..." : "Daftar"}
           </motion.button>
         </form>
+        <Link
+          href="/auth/login"
+          className="block text-center text-sm text-blue-500 dark:text-neon hover:underline"
+        >
+          Sudah punya akun? Login
+        </Link>
       </GlassCard>
     </div>
   );


### PR DESCRIPTION
## Summary
- make it easier to move between login and register

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856c5b3c5008331a2d14c7d7d711abf