### PR TITLE
Add SweetAlert2 alerts to auth flow

### DIFF
--- a/app/auth/login/page.jsx
+++ b/app/auth/login/page.jsx
@@ -3,27 +3,28 @@ import { useState } from "react";
 import GlassCard from "@/components/GlassCard";
 import { GoogleLogin } from "@react-oauth/google";
 import { motion } from "framer-motion";
+import { successAlert, errorAlert } from "@/utils/alert";
 
 export default function LoginPage() {
   const [email, setEmail] = useState(""); 
   const [password, setPassword] = useState("");
-  const [err, setErr] = useState(null); 
   const [loading, setLoading] = useState(false);
 
   const handleLogin = async e => {
     e.preventDefault();
-    setLoading(true); setErr(null);
+    setLoading(true);
     try {
-      const res = await fetch("/api/auth/login", { 
+      const res = await fetch("/api/auth/login", {
         method: "POST",
-        headers: { "Content-Type": "application/json" }, 
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, password })
       });
       const data = await res.json();
       if (!data.status) throw new Error(data.error || "Login gagal");
       localStorage.setItem("token", data.token);
+      await successAlert("Berhasil login");
       window.location.href = "/dashboard";
-    } catch (e) { setErr(e.message); }
+    } catch (e) { errorAlert("Login gagal", e.message); }
     setLoading(false);
   };
 
@@ -48,9 +49,6 @@ export default function LoginPage() {
             onChange={e => setPassword(e.target.value)} 
             required 
           />
-          {err && (
-            <motion.div animate={{ scale: [0.8, 1] }} className="text-sm text-red-500">{err}</motion.div>
-          )}
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
@@ -69,16 +67,19 @@ export default function LoginPage() {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ credential: credentialResponse.credential })
               })
-              .then(res => res.json())
-              .then(data => {
-                if (data.token) {
-                  localStorage.setItem("token", data.token);
-                  window.location.href = "/dashboard";
-                }
-              })
-              .catch(() => setErr("Login Google gagal"));
+                .then(res => res.json())
+                .then(async data => {
+                  if (data.token) {
+                    localStorage.setItem("token", data.token);
+                    await successAlert("Berhasil login");
+                    window.location.href = "/dashboard";
+                  } else {
+                    throw new Error();
+                  }
+                })
+                .catch(() => errorAlert("Login Google gagal"));
             }}
-            onError={() => setErr("Login Google gagal")}
+            onError={() => errorAlert("Login Google gagal")}
             useOneTap
           />
         </div>

--- a/app/auth/logout/page.jsx
+++ b/app/auth/logout/page.jsx
@@ -1,0 +1,14 @@
+"use client";
+import { useEffect } from "react";
+import { successAlert } from "@/utils/alert";
+
+export default function LogoutPage() {
+  useEffect(() => {
+    localStorage.removeItem("token");
+    successAlert("Berhasil logout").then(() => {
+      window.location.href = "/auth/login";
+    });
+  }, []);
+
+  return null;
+}

--- a/app/auth/register/page.jsx
+++ b/app/auth/register/page.jsx
@@ -2,13 +2,15 @@
 import { useState } from "react";
 import GlassCard from "@/components/GlassCard";
 import { motion } from "framer-motion";
+import { successAlert, errorAlert } from "@/utils/alert";
 
 export default function RegisterPage() {
   const [form, setForm] = useState({ email: "", password: "", name: "" });
-  const [err, setErr] = useState(null), [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const handleRegister = async e => {
-    e.preventDefault(); setLoading(true); setErr(null);
+    e.preventDefault();
+    setLoading(true);
     try {
       const res = await fetch("/api/auth/register", {
         method: "POST", headers: { "Content-Type": "application/json" },
@@ -26,8 +28,9 @@ export default function RegisterPage() {
       if (data.token) {
         localStorage.setItem("token", data.token);
       }
+      await successAlert("Registrasi berhasil");
       window.location.href = "/dashboard";
-    } catch (e) { setErr(e.message); }
+    } catch (e) { errorAlert("Register gagal", e.message); }
     setLoading(false);
   };
 
@@ -60,11 +63,6 @@ export default function RegisterPage() {
             onChange={e => setForm(f => ({ ...f, password: e.target.value }))}
             required
           />
-          {err && (
-            <motion.div animate={{ scale: [0.8, 1] }} className="text-sm text-red-500">
-              {err}
-            </motion.div>
-          )}
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}

--- a/components/LiveChatWidget.jsx
+++ b/components/LiveChatWidget.jsx
@@ -1,11 +1,13 @@
 "use client";
 import { useEffect } from "react";
+import { errorAlert } from "@/utils/alert";
 export default function LiveChatWidget() {
   useEffect(() => {
     const crispId = process.env.NEXT_PUBLIC_CRISP_ID;
     if (!crispId) {
-      console.warn(
-        "Crisp chat disabled: NEXT_PUBLIC_CRISP_ID environment variable not set."
+      errorAlert(
+        "Crisp chat disabled",
+        "NEXT_PUBLIC_CRISP_ID environment variable not set."
       );
       return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,9 @@
         "react-heatmap-grid": "^0.9.1",
         "react-scroll-parallax": "^3.4.5",
         "recharts": "^2.8.0",
-        "tailwindcss": "^3.4.0"
+        "tailwindcss": "^3.4.0",
+        "sweetalert2": "^11.10.0",
+        "@sweetalert2/theme-dark": "^5.0.15"
       },
       "devDependencies": {
         "eslint": "8.56.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "qrcode.react": "^3.1.0",
     "recharts": "^2.8.0",
     "react-scroll-parallax": "^3.4.5",
-    "react-heatmap-grid": "^0.9.1"
+    "react-heatmap-grid": "^0.9.1",
+    "sweetalert2": "^11.10.0",
+    "@sweetalert2/theme-dark": "^5.0.15"
   },
   "devDependencies": {
     "eslint": "8.56.0",

--- a/utils/alert.js
+++ b/utils/alert.js
@@ -1,0 +1,36 @@
+import Swal from 'sweetalert2';
+import '@sweetalert2/theme-dark/dark.css';
+
+const baseOptions = {
+  confirmButtonColor: '#3b82f6',
+};
+
+export function successAlert(title, text = '') {
+  return Swal.fire({
+    ...baseOptions,
+    icon: 'success',
+    title,
+    text,
+  });
+}
+
+export function errorAlert(title, text = '') {
+  return Swal.fire({
+    ...baseOptions,
+    icon: 'error',
+    title,
+    text,
+  });
+}
+
+export function confirmAlert(title, text = '') {
+  return Swal.fire({
+    ...baseOptions,
+    icon: 'question',
+    title,
+    text,
+    showCancelButton: true,
+    confirmButtonText: 'Ya',
+    cancelButtonText: 'Batal',
+  });
+}


### PR DESCRIPTION
## Summary
- add sweetalert2 with dark theme
- create `utils/alert.js` wrapper
- use alerts for login and register flows
- show logout page with alert
- notify via alert when Crisp env missing

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856c5b4dac083319736f8e9162508d5