### PR TITLE
Add logout helper and profile page

### DIFF
--- a/app/profile/page.jsx
+++ b/app/profile/page.jsx
@@ -1,0 +1,24 @@
+"use client";
+import Navbar from "@/components/Navbar";
+import GlassCard from "@/components/GlassCard";
+import useAuth from "@/hooks/useAuth";
+import useUser from "@/hooks/useUser";
+
+export default function ProfilePage() {
+  const authUser = useAuth();
+  const { user, logout } = useUser();
+  if (!authUser) return null;
+  return (
+    <div>
+      <Navbar />
+      <div className="p-8">
+        <GlassCard className="max-w-md mx-auto">
+          <h2 className="text-xl font-bold mb-4">Profil</h2>
+          <div className="mb-2">Nama: {user?.name}</div>
+          <div className="mb-4">Role: {user?.role}</div>
+          <button className="btn" onClick={logout}>Logout</button>
+        </GlassCard>
+      </div>
+    </div>
+  );
+}

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -1,9 +1,14 @@
 "use client";
+import { useState } from "react";
+import Link from "next/link";
 import ThemeToggle from "./ThemeToggle";
 import NotificationBell from "./NotificationBell";
-import Link from "next/link";
+import useUser from "@/hooks/useUser";
 
 export default function Navbar() {
+  const { user, logout } = useUser();
+  const [open, setOpen] = useState(false);
+
   return (
     <nav className="flex items-center justify-between px-6 md:px-12 py-4 glass shadow-glass sticky top-0 z-50 backdrop-blur-2xl">
       <Link href="/" className="font-extrabold text-2xl text-blue-500 dark:text-neon tracking-wider select-none">
@@ -13,9 +18,40 @@ export default function Navbar() {
         <Link href="/products" className="font-semibold text-base hover:text-blue-500 dark:hover:text-neon transition">
           Produk
         </Link>
-        <Link href="/auth/login" className="font-semibold text-base hover:text-blue-500 dark:hover:text-neon transition">
-          Login
-        </Link>
+        {user ? (
+          <div className="relative">
+            <button
+              onClick={() => setOpen((v) => !v)}
+              className="font-semibold text-base hover:text-blue-500 dark:hover:text-neon transition"
+            >
+              {user.name}
+            </button>
+            {open && (
+              <div className="absolute right-0 mt-2 w-32 bg-white dark:bg-zinc-800 rounded-xl shadow-lg z-50 p-2 glass">
+                <Link
+                  href="/profile"
+                  className="block px-4 py-2 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                  onClick={() => setOpen(false)}
+                >
+                  Profil
+                </Link>
+                <button
+                  onClick={() => {
+                    setOpen(false);
+                    logout();
+                  }}
+                  className="block w-full text-left px-4 py-2 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                >
+                  Logout
+                </button>
+              </div>
+            )}
+          </div>
+        ) : (
+          <Link href="/auth/login" className="font-semibold text-base hover:text-blue-500 dark:hover:text-neon transition">
+            Login
+          </Link>
+        )}
         <NotificationBell />
         <ThemeToggle />
       </div>

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -1,9 +1,14 @@
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import useUser from "./useUser";
+
 export default function useAuth(redirect = "/auth/login") {
-  const user = useUser();
+  const { user } = useUser();
   const router = useRouter();
-  useEffect(() => { if (!user) router.push(redirect); }, [user, router]);
+
+  useEffect(() => {
+    if (!user) router.push(redirect);
+  }, [user, router]);
+
   return user;
 }

--- a/hooks/useUser.js
+++ b/hooks/useUser.js
@@ -1,10 +1,21 @@
 import { useEffect, useState } from "react";
+
 export default function useUser() {
   const [user, setUser] = useState(null);
+
   useEffect(() => {
     const token = localStorage.getItem("token");
-    if (token) fetch("/api/auth/me", { headers: { Authorization: `Bearer ${token}` } })
-      .then(r => r.json()).then(d => d.status && setUser(d.data));
+    if (token) {
+      fetch("/api/auth/me", { headers: { Authorization: `Bearer ${token}` } })
+        .then((r) => r.json())
+        .then((d) => d.status && setUser(d.data));
+    }
   }, []);
-  return user;
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    setUser(null);
+  };
+
+  return { user, logout };
 }


### PR DESCRIPTION
## Summary
- extend `useUser` to expose `logout()`
- update `useAuth` to consume new return shape
- show a profile dropdown in `Navbar` with logout action
- add a simple profile page with logout button

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6856c5b5bd248331b4a0b123d5961bd3