### PR TITLE
Add hidden labels to auth forms

### DIFF
--- a/app/auth/login/page.jsx
+++ b/app/auth/login/page.jsx
@@ -32,21 +32,29 @@ export default function LoginPage() {
       <GlassCard className="w-full max-w-md space-y-8">
         <h2 className="text-2xl font-bold text-center mb-4">Login ke FuturaShop</h2>
         <form className="space-y-6" onSubmit={handleLogin}>
+          <label htmlFor="login-email" className="sr-only">
+            Email
+          </label>
           <input
+            id="login-email"
             type="email"
             className="w-full px-4 py-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition"
-            placeholder="Email" 
-            value={email} 
-            onChange={e => setEmail(e.target.value)} 
-            required 
+            placeholder="Email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
           />
+          <label htmlFor="login-password" className="sr-only">
+            Password
+          </label>
           <input
+            id="login-password"
             type="password"
             className="w-full px-4 py-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition"
-            placeholder="Password" 
-            value={password} 
-            onChange={e => setPassword(e.target.value)} 
-            required 
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
           />
           {err && (
             <motion.div animate={{ scale: [0.8, 1] }} className="text-sm text-red-500">{err}</motion.div>

--- a/app/auth/register/page.jsx
+++ b/app/auth/register/page.jsx
@@ -36,7 +36,11 @@ export default function RegisterPage() {
       <GlassCard className="w-full max-w-md space-y-8">
         <h2 className="text-2xl font-bold text-center mb-4">Buat Akun FuturaShop</h2>
         <form className="space-y-4" onSubmit={handleRegister}>
+          <label htmlFor="register-name" className="sr-only">
+            Nama
+          </label>
           <input
+            id="register-name"
             type="text"
             className="w-full p-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition"
             placeholder="Nama"
@@ -44,7 +48,11 @@ export default function RegisterPage() {
             onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
             required
           />
+          <label htmlFor="register-email" className="sr-only">
+            Email
+          </label>
           <input
+            id="register-email"
             type="email"
             className="w-full p-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition"
             placeholder="Email"
@@ -52,7 +60,11 @@ export default function RegisterPage() {
             onChange={e => setForm(f => ({ ...f, email: e.target.value }))}
             required
           />
+          <label htmlFor="register-password" className="sr-only">
+            Password
+          </label>
           <input
+            id="register-password"
             type="password"
             className="w-full p-3 rounded-lg bg-white/60 dark:bg-zinc-900/70 border outline-blue-400 transition"
             placeholder="Password"


### PR DESCRIPTION
## Summary
- improve accessibility of login and register forms by adding hidden `<label>` elements

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856c5b7e88c8331b4fd53d58362290d