### PR TITLE
Fix FilterBar default colors

### DIFF
--- a/components/FilterBar.jsx
+++ b/components/FilterBar.jsx
@@ -4,7 +4,7 @@ export default function FilterBar({ categories = [], selected, onChange }) {
   return (
     <div className="flex flex-wrap gap-2 mb-6">
       <button
-        className={`px-3 py-1 rounded ${!selected ? "bg-blue-500 text-white" : "bg-darkBgSoft dark:text-white"}`}
+        className={`px-3 py-1 rounded ${!selected ? "bg-blue-500 text-white" : "bg-gray-100 dark:bg-darkBgSoft text-gray-800 dark:text-gray-200"}`}
         onClick={() => onChange("")}
       >
         Semua
@@ -12,7 +12,7 @@ export default function FilterBar({ categories = [], selected, onChange }) {
       {categories.map(cat => (
         <button
           key={cat}
-          className={`px-3 py-1 rounded ${selected === cat ? "bg-blue-500 text-white" : "bg-darkBgSoft dark:text-white"}`}
+          className={`px-3 py-1 rounded ${selected === cat ? "bg-blue-500 text-white" : "bg-gray-100 dark:bg-darkBgSoft text-gray-800 dark:text-gray-200"}`}
           onClick={() => onChange(cat)}
         >
           {cat}


### PR DESCRIPTION
## Summary
- tweak `FilterBar` background so inactive buttons use light mode and dark mode colors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6856c5c5bc4c8331a55f2dea03c8d43b